### PR TITLE
Colorbar x_tick_labels update

### DIFF
--- a/plot_aniso.m
+++ b/plot_aniso.m
@@ -73,7 +73,7 @@ function plot_transitions(states, transitions, varargin)
 
     colormap('jet');
     colorbar('southoutside');
-    x_tick_labels = compose('10^{%d}', (lower_bound:bound_spacing:upper_bound));
+    x_tick_labels = compose('10^{%d}', (lower_bound:(((upper_bound - lower_bound) / bound_spacing)+1):upper_bound));
     colorbar('southoutside', 'XTick', 0:(1 / (bound_spacing - 1)):1, 'XTickLabel', x_tick_labels);
 end
 


### PR DESCRIPTION
Previously, labels on colorbars were separated by the bound spacing rather than into a number of ticks equal to the bound spacing. Updated code sets bound_spacing as humber of ticks and calculated the spacing based on the number of ticks.