### PR TITLE
Updated state labels and colorbar intervals

### DIFF
--- a/plot_aniso.m
+++ b/plot_aniso.m
@@ -22,7 +22,8 @@ function make_figure()
 end
 
 function print_labels(states, wavefunctions)
-    text(-states(:, 1) + 5.0, states(:, 2), compose('$\\mathbf{%.1f\\%%}$', max(wavefunctions) ./ sum(wavefunctions) .* 100), 'HorizontalAlignment', 'center', 'VerticalAlignment', 'middle', 'Interpreter', 'latex', 'Fontsize', 10.5, 'Clipping', 'on');
+    %text(-states(:, 1) + 5.0, states(:, 2), compose('$\\mathbf{%.1f\\%%}$', max(wavefunctions) ./ sum(wavefunctions) .* 100), 'HorizontalAlignment', 'center', 'VerticalAlignment', 'middle', 'Interpreter', 'latex', 'Fontsize', 10.5, 'Clipping', 'on');
+    text(-states(:, 1) + 5.0, states(:, 2), compose('$\\mathsf{%.1f\\%%}$', (max(wavefunctions) + wavefunctions(abs([17 49 81 113 145 177 209 241]' - find(wavefunctions == max(wavefunctions))))') ./ sum(wavefunctions) .* 100), 'HorizontalAlignment', 'center', 'VerticalAlignment', 'middle', 'Interpreter', 'latex', 'Fontsize', 10.5, 'Clipping', 'on');
     wavefunction_labels = compose('$\\mathbf{\\pm|\\frac{%d}{2}\\rangle}$', abs(-15:2:15));
     [~, wavefunction_indices] = max(wavefunctions);
     text(states(:, 1) - 5, states(:, 2), wavefunction_labels(wavefunction_indices), 'HorizontalAlignment', 'center', 'VerticalAlignment', 'middle', 'Interpreter', 'latex', 'Fontsize', 13.5, 'Clipping', 'on');
@@ -75,8 +76,10 @@ function plot_transitions(states, transitions, varargin)
 
     colormap('jet');
     colorbar('southoutside');
-    x_tick_labels = compose('10^{%d}', (lower_bound:bound_spacing:upper_bound));
-    colorbar('southoutside', 'XTick', 0:(1 / (bound_spacing - 1)):1, 'XTickLabel', x_tick_labels);
+    x_tick_labels = compose('10^{%d}', (lower_bound:(((upper_bound - lower_bound) / (bound_spacing-1))):upper_bound));
+    cbar = colorbar('southoutside', 'XTick', 0:(1 / (bound_spacing - 1)):1, 'XTickLabel', x_tick_labels);
+    cbar.Label.String = 'Transition Matrix Element'; cbar.Label.FontSize = 16; cbar.Label.FontWeight = 'bold';
+    cbar.Box = 'on'; cbar.LineWidth = 1.5;
 end
 
 function plot_states(states, padding)


### PR DESCRIPTION
For state labels: SPECIFICALLY FOR ER3+ SINGLE_ANISO: Rough fix making each state label the combination of contributions of opposite moment states, i.e. percentage is of +/- 15/2 in ground state instead of the maximum of either +15/2 or -15/2

For Colorbar: added label to colorbar and allowed for tuning of font size, weight, and label (using cbar variable).
Also: improved x_tick_label composition (line 79), changing spacing from "bound spacing" (which is currently the number of ticks) to a function to calculate the actual interval between each tick using "bound spacing" as the desired number of ticks. Upper bound, lower bound, and bound spacing must be chosen such that (upper_bound-lower_bound)/(bound_spacing-1) is an integer to get good labels.